### PR TITLE
Bump dependencies and update version to 26.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "jonaebert.de",
-	"version": "26.5.1",
+	"version": "26.5.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "jonaebert.de",
-			"version": "26.5.1",
+			"version": "26.5.2",
 			"dependencies": {
 				"sanitize-html": "^2.17.4",
 				"svelte-fa": "^4.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
 			"name": "jonaebert.de",
 			"version": "26.5.1",
 			"dependencies": {
-				"sanitize-html": "^2.17.3",
+				"sanitize-html": "^2.17.4",
 				"svelte-fa": "^4.0.4"
 			},
 			"devDependencies": {
@@ -17,7 +17,7 @@
 				"@fortawesome/free-brands-svg-icons": "^7.2.0",
 				"@fortawesome/free-solid-svg-icons": "^7.2.0",
 				"@sveltejs/adapter-node": "^5.5.4",
-				"@sveltejs/kit": "^2.58.0",
+				"@sveltejs/kit": "^2.60.1",
 				"@sveltejs/vite-plugin-svelte": "^7.0.0",
 				"@tailwindcss/vite": "^4.3.0",
 				"@types/eslint": "^9.6.1",
@@ -32,7 +32,7 @@
 				"openapi-typescript": "^7.13.0",
 				"prettier": "^3.8.3",
 				"prettier-plugin-svelte": "^3.5.1",
-				"svelte": "^5.55.5",
+				"svelte": "^5.55.9",
 				"svelte-check": "^4.4.8",
 				"svelte-routing": "^2.13.0",
 				"tailwindcss": "^4.3.0",
@@ -1256,9 +1256,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@sveltejs/acorn-typescript": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
-			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.10.tgz",
+			"integrity": "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==",
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -1281,9 +1281,9 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "2.58.0",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.58.0.tgz",
-			"integrity": "sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==",
+			"version": "2.60.1",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.60.1.tgz",
+			"integrity": "sha512-mQjlkNo+rJvpln7V2IGY2j99BqhcFbS4UN0AQNKNYfhBAFZTuCDAdW3a1sgf330mvtNvsBXn3HpAhcmvdJTcIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1292,7 +1292,7 @@
 				"@types/cookie": "^0.6.0",
 				"acorn": "^8.14.1",
 				"cookie": "^0.6.0",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.2",
 				"kleur": "^4.1.5",
 				"magic-string": "^0.30.5",
@@ -2187,6 +2187,12 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/dayjs": {
+			"version": "1.11.20",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+			"license": "MIT"
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2232,9 +2238,9 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "5.6.4",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
-			"integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
+			"version": "5.8.1",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
+			"integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
 			"license": "MIT"
 		},
 		"node_modules/dom-serializer": {
@@ -2615,9 +2621,9 @@
 			}
 		},
 		"node_modules/esrap": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.5.tgz",
-			"integrity": "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig==",
+			"version": "2.2.9",
+			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
+			"integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3091,6 +3097,15 @@
 			"integrity": "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/launder": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+			"integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+			"license": "MIT",
+			"dependencies": {
+				"dayjs": "^1.11.7"
+			}
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -4018,15 +4033,16 @@
 			}
 		},
 		"node_modules/sanitize-html": {
-			"version": "2.17.3",
-			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
-			"integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+			"version": "2.17.4",
+			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.4.tgz",
+			"integrity": "sha512-2HW7v2ol/uAM7sX4hbD8Z59OGWmAPrvjL8E71UWlBcj6m+kcF6ilQBLny+cIgY214QJeJT5tQuxKKqX0SQqjGQ==",
 			"license": "MIT",
 			"dependencies": {
 				"deepmerge": "^4.2.2",
 				"escape-string-regexp": "^4.0.0",
 				"htmlparser2": "^10.1.0",
 				"is-plain-object": "^5.0.0",
+				"launder": "^1.7.1",
 				"parse-srcset": "^1.0.2",
 				"postcss": "^8.3.11"
 			}
@@ -4125,23 +4141,23 @@
 			}
 		},
 		"node_modules/svelte": {
-			"version": "5.55.5",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.5.tgz",
-			"integrity": "sha512-2uCs/LZ9us+AktdzYJM8OcxQ8qnPS1kpaO7syGT/MgO+6Qr1Ybl+TqPq+97u7PHqmmMlye5ZkoyXONy5mjjAbw==",
+			"version": "5.55.9",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.9.tgz",
+			"integrity": "sha512-fTjjT8cHLDwigcu2j3pv7Jq04LklXevPB8uBgyHNiTXv+RMNvVnrjS4UEYrLMkhuq1vpCodHjiW+z/95SDs/fg==",
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
-				"@sveltejs/acorn-typescript": "^1.0.5",
+				"@sveltejs/acorn-typescript": "^1.0.10",
 				"@types/estree": "^1.0.5",
 				"@types/trusted-types": "^2.0.7",
 				"acorn": "^8.12.1",
 				"aria-query": "5.3.1",
 				"axobject-query": "^4.1.0",
 				"clsx": "^2.1.1",
-				"devalue": "^5.6.4",
+				"devalue": "^5.8.1",
 				"esm-env": "^1.2.1",
-				"esrap": "^2.2.4",
+				"esrap": "^2.2.9",
 				"is-reference": "^3.0.3",
 				"locate-character": "^3.0.0",
 				"magic-string": "^0.30.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "jonaebert.de",
-	"version": "26.5.1",
+	"version": "26.5.2",
 	"private": true,
 	"engines": {
 		"node": ">=20.19 || >=22.13 || >=24 || >=25"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@fortawesome/free-brands-svg-icons": "^7.2.0",
 		"@fortawesome/free-solid-svg-icons": "^7.2.0",
 		"@sveltejs/adapter-node": "^5.5.4",
-		"@sveltejs/kit": "^2.58.0",
+		"@sveltejs/kit": "^2.60.1",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
 		"@tailwindcss/vite": "^4.3.0",
 		"@types/eslint": "^9.6.1",
@@ -38,7 +38,7 @@
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^3.5.1",
 		"@types/sanitize-html": "^2.13.0",
-		"svelte": "^5.55.5",
+		"svelte": "^5.55.9",
 		"svelte-check": "^4.4.8",
 		"svelte-routing": "^2.13.0",
 		"tailwindcss": "^4.3.0",
@@ -47,7 +47,7 @@
 		"vite": "^8.0.10"
 	},
 	"dependencies": {
-		"sanitize-html": "^2.17.3",
+		"sanitize-html": "^2.17.4",
 		"svelte-fa": "^4.0.4"
 	},
 	"type": "module"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 26.5.2
  * Updated SvelteKit, Svelte, and sanitize-html dependencies to latest stable versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jonaebert/jonaebert.de/pull/436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->